### PR TITLE
401 「unathorized 」のリターンオブジェクトが見つからないエラー

### DIFF
--- a/Sources/BSApiClient/BSApiClient.swift
+++ b/Sources/BSApiClient/BSApiClient.swift
@@ -12,71 +12,74 @@ public class BSApiClient {
     private let decoder: JSONDecoder
     public let waitTime: Int
     public var mockMode: Bool
-    
+
     public init(decoder: JSONDecoder = .default, waitTime: Int = 20, isMockMode: Bool = false) {
         self.decoder = decoder
         self.waitTime = waitTime
         self.mockMode = isMockMode
     }
-    
+
     public func fetch<T: Codable>(_ request: BSRequestable, session: URLSession = .shared) async throws -> BSResponse<T> {
         guard var urlRequest = mockMode ? request.mockModeURLRequest : request.urlRequst else {
             throw BSNetworkError.invalidRequest
         }
-        
+
         urlRequest.timeoutInterval = TimeInterval(waitTime)
-        
-        
+
         let (data, response) = try await session.data(for: urlRequest)
-        
+
         guard let httpResponse = response as? HTTPURLResponse else {
             throw BSNetworkError.invalidResponse
         }
-        
+
         let statusCode = httpResponse.statusCode
-        
+
         switch statusCode {
         case 200...299:
             do {
                 var body: T? = nil
-                
+
                 if !data.isEmpty {
                     body = try self.decoder.decode(T.self, from: data)
                 }
-                
+
                 return BSResponse(code: statusCode, body: body)
             } catch {
                 throw BSNetworkError.parseError(error: error)
             }
-            
+
         case 300...399:
             guard let transferError = BSNetworkError.TransferError(rawValue: statusCode) else {
                 throw BSNetworkError.unknown(message: "\(statusCode)")
             }
-            
+
             throw BSNetworkError.transfer(transferError, data: data)
-            
+
+        case 401:
+            guard let serverError = BSNetworkError.ClientError(rawValue: statusCode) else {
+                throw BSNetworkError.unknown(message: "\(statusCode)")
+            }
+            throw BSNetworkError.client(.unauthorized, data: data)
+
         case 400...499:
             guard let clientError = BSNetworkError.ClientError(rawValue: statusCode) else {
                 throw BSNetworkError.unknown(message: "\(statusCode)")
             }
-            
+
             throw BSNetworkError.client(clientError, data: data)
-            
+
         case 500...599:
             guard let serverError = BSNetworkError.ServerError(rawValue: statusCode) else {
                 throw BSNetworkError.unknown(message: "\(statusCode)")
             }
-            
+
             throw BSNetworkError.server(serverError, data: data)
-            
+
         default:
             throw BSNetworkError.unknown(message: "\(statusCode)")
         }
     }
-    
-    
-    
+
     public func getFileSize(fileURL: URL) async throws -> Int {
         try await withCheckedThrowingContinuation { continuation in
             var request = URLRequest(
@@ -85,18 +88,18 @@ public class BSApiClient {
                 timeoutInterval: TimeInterval(waitTime)
             )
             request.httpMethod = BSRequestMethod.head.rawValue
-            
+
             URLSession.shared.dataTask(with: request) { _, response, error in
                 if let error = error {
                     print("[BSApiClient] \(error.localizedDescription)")
                     return continuation.resume(throwing: error)
                 }
-                
+
                 guard let response = response else {
                     print("[BSApiClient] invalid response.")
                     return continuation.resume(throwing: BSNetworkError.invalidResponse)
                 }
-                
+
                 let contentLength: Int64 = response.expectedContentLength ?? NSURLSessionTransferSizeUnknown
                 return continuation.resume(returning: Int(contentLength))
             }

--- a/Sources/BSApiClient/BSApiClient.swift
+++ b/Sources/BSApiClient/BSApiClient.swift
@@ -73,17 +73,13 @@ public class BSApiClient {
             default:
                 throw BSNetworkError.unknown(message: "\(statusCode)")
             }
-        } catch {
-            if let nsError = error as NSError? {
-                switch nsError.code {
-                case NSURLErrorTimedOut:
-                    throw BSNetworkError.client(.requestTimeout, data: nil)
-                case NSURLErrorNotConnectedToInternet, NSURLErrorDataNotAllowed:
-                    throw BSNetworkError.collectionLost
-                default:
-                    throw BSNetworkError.unknown(message: nsError.localizedDescription)
-                }
-            } else {
+        } catch let error as NSError {
+            switch error.code {
+            case NSURLErrorTimedOut:
+                throw BSNetworkError.client(.requestTimeout, data: nil)
+            case NSURLErrorNotConnectedToInternet, NSURLErrorDataNotAllowed:
+                throw BSNetworkError.collectionLost
+            default:
                 throw BSNetworkError.unknown(message: error.localizedDescription)
             }
         }

--- a/Sources/BSApiClient/BSApiClient.swift
+++ b/Sources/BSApiClient/BSApiClient.swift
@@ -18,74 +18,64 @@ public class BSApiClient {
         self.waitTime = waitTime
         self.mockMode = isMockMode
     }
-
+    
     public func fetch<T: Codable>(_ request: BSRequestable, session: URLSession = .shared) async throws -> BSResponse<T> {
         guard var urlRequest = mockMode ? request.mockModeURLRequest : request.urlRequst else {
             throw BSNetworkError.invalidRequest
         }
-
+        
         urlRequest.timeoutInterval = TimeInterval(waitTime)
-
-        do {
-            let (data, response) = try await session.data(for: urlRequest)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw BSNetworkError.invalidResponse
+        
+        
+        let (data, response) = try await session.data(for: urlRequest)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw BSNetworkError.invalidResponse
+        }
+        
+        let statusCode = httpResponse.statusCode
+        
+        switch statusCode {
+        case 200...299:
+            do {
+                var body: T? = nil
+                
+                if !data.isEmpty {
+                    body = try self.decoder.decode(T.self, from: data)
+                }
+                
+                return BSResponse(code: statusCode, body: body)
+            } catch {
+                throw BSNetworkError.parseError(error: error)
             }
-
-            let statusCode = httpResponse.statusCode
-
-            switch statusCode {
-            case 200...299:
-                do {
-                    var body: T? = nil
-
-                    if !data.isEmpty {
-                        body = try self.decoder.decode(T.self, from: data)
-                    }
-
-                    return BSResponse(code: statusCode, body: body)
-                } catch {
-                    throw BSNetworkError.parseError(error: error)
-                }
-
-            case 300...399:
-                guard let transferError = BSNetworkError.TransferError(rawValue: statusCode) else {
-                    throw BSNetworkError.unknown(message: "\(statusCode)")
-                }
-
-                throw BSNetworkError.transfer(transferError, data: data)
-
-            case 400...499:
-                guard let clientError = BSNetworkError.ClientError(rawValue: statusCode) else {
-                    throw BSNetworkError.unknown(message: "\(statusCode)")
-                }
-
-                throw BSNetworkError.client(clientError, data: data)
-
-            case 500...599:
-                guard let serverError = BSNetworkError.ServerError(rawValue: statusCode) else {
-                    throw BSNetworkError.unknown(message: "\(statusCode)")
-                }
-
-                throw BSNetworkError.server(serverError, data: data)
-
-            default:
+            
+        case 300...399:
+            guard let transferError = BSNetworkError.TransferError(rawValue: statusCode) else {
                 throw BSNetworkError.unknown(message: "\(statusCode)")
             }
-        } catch let error as NSError {
-            switch error.code {
-            case NSURLErrorTimedOut:
-                throw BSNetworkError.client(.requestTimeout, data: nil)
-            case NSURLErrorNotConnectedToInternet, NSURLErrorDataNotAllowed:
-                throw BSNetworkError.collectionLost
-            default:
-                throw BSNetworkError.unknown(message: error.localizedDescription)
+            
+            throw BSNetworkError.transfer(transferError, data: data)
+            
+        case 400...499:
+            guard let clientError = BSNetworkError.ClientError(rawValue: statusCode) else {
+                throw BSNetworkError.unknown(message: "\(statusCode)")
             }
+            
+            throw BSNetworkError.client(clientError, data: data)
+            
+        case 500...599:
+            guard let serverError = BSNetworkError.ServerError(rawValue: statusCode) else {
+                throw BSNetworkError.unknown(message: "\(statusCode)")
+            }
+            
+            throw BSNetworkError.server(serverError, data: data)
+            
+        default:
+            throw BSNetworkError.unknown(message: "\(statusCode)")
         }
     }
-
-
+    
+    
     
     public func getFileSize(fileURL: URL) async throws -> Int {
         try await withCheckedThrowingContinuation { continuation in
@@ -106,7 +96,7 @@ public class BSApiClient {
                     print("[BSApiClient] invalid response.")
                     return continuation.resume(throwing: BSNetworkError.invalidResponse)
                 }
-
+                
                 let contentLength: Int64 = response.expectedContentLength ?? NSURLSessionTransferSizeUnknown
                 return continuation.resume(returning: Int(contentLength))
             }


### PR DESCRIPTION
401 「unathorized 」のリターンオブジェクトが見つからないエラー

## 概要
トークン更新時の401エラー管理の欠落に関する問題を修正。

## 修正内容
- [x] バグ修正
- [ ] 新機能の追加
- [ ] 改善 / リファクタリング
- [ ] ドキュメントの更新
- [ ] その他（詳細を記入）

### 詳細
401ケースの 「BSApiClient 」の 「fetch 」関数を追加した。

## 動作確認
- [ ] ローカル環境での動作確認
- [ ] 単体テストの実施
- [x] Swift Package Managerのビルド
- [ ] 必要に応じてCIの実行
